### PR TITLE
Update utils.R

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -194,7 +194,7 @@
         SeuratObject::CreateAssayObject
       }
       suppressWarnings(
-        sc[[name]] <- fn(data = as.matrix(t(enrichment)))
+        sc[[name]] <- fn(data = as.matrix(Matrix::t(enrichment)))
       )
     } else {
       warning("SeuratObject package is required to add enrichment to Seurat object.")


### PR DESCRIPTION
Explicit namespace reference for transposing matrix using Matrix::t(). See issue #157. 